### PR TITLE
self.triggers.name not valorized during destroy, now use local value

### DIFF
--- a/azuredevops_build_definition_tls_cert/main.tf
+++ b/azuredevops_build_definition_tls_cert/main.tf
@@ -194,7 +194,7 @@ resource "null_resource" "this" {
   provisioner "local-exec" {
     command = <<EOT
       CREDENTIAL_VALUE=$(az ad sp create-for-rbac \
-        --name "azdo-sp-acme-challenge-${self.triggers.name}" \
+        --name "azdo-sp-acme-challenge-${local.secret_name}" \
         --role "DNS Zone Contributor" \
         --scope "/subscriptions/${self.triggers.subscription_id}/resourceGroups/${self.triggers.dns_zone_resource_group}/providers/Microsoft.Network/dnszones/${self.triggers.dns_zone_name}/TXT/${trim("_acme-challenge.${self.triggers.dns_record_name}", ".")}" \
         -o json)
@@ -202,7 +202,7 @@ resource "null_resource" "this" {
       az keyvault secret set \
         --subscription "${self.triggers.credential_subcription}" \
         --vault-name "${self.triggers.credential_key_vault_name}" \
-        --name "azdo-sp-acme-challenge-${self.triggers.name}" \
+        --name "azdo-sp-acme-challenge-${local.secret_name}" \
         --value "$CREDENTIAL_VALUE"
     EOT
   }
@@ -214,7 +214,7 @@ resource "null_resource" "this" {
       SERVICE_PRINCIPAL_ID=$(az keyvault secret show \
         --subscription "${self.triggers.credential_subcription}" \
         --vault-name "${self.triggers.credential_key_vault_name}" \
-        --name "azdo-sp-acme-challenge-${self.triggers.name}" \
+        --name "azdo-sp-acme-challenge-${local.secret_name}" \
         -o tsv --query value | jq -r '.appId')
 
       az ad sp delete --id "$SERVICE_PRINCIPAL_ID"
@@ -222,14 +222,14 @@ resource "null_resource" "this" {
       az keyvault secret delete \
         --subscription "${self.triggers.credential_subcription}" \
         --vault-name "${self.triggers.credential_key_vault_name}" \
-        --name "azdo-sp-acme-challenge-${self.triggers.name}"
+        --name "azdo-sp-acme-challenge-${local.secret_name}"
       
       sleep 60
 
       az keyvault secret purge \
         --subscription "${self.triggers.credential_subcription}" \
         --vault-name "${self.triggers.credential_key_vault_name}" \
-        --name "azdo-sp-acme-challenge-${self.triggers.name}"
+        --name "azdo-sp-acme-challenge-${local.secret_name}"
       
       sleep 60
     EOT


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

````
resource "null_resource" "this" {
  # needs az cli > 2.0.81
  # see https://github.com/Azure/azure-cli/issues/12152

  triggers = {
    renew_token               = var.renew_token
    subscription_id           = var.subscription_id
    subscription_name         = var.subscription_name
    credential_subcription    = var.credential_subcription
    credential_key_vault_name = var.credential_key_vault_name
    dns_record_name           = var.dns_record_name
    dns_zone_name             = var.dns_zone_name
    name                      = local.secret_name
    dns_zone_resource_group   = var.dns_zone_resource_group
  }

  # https://docs.microsoft.com/it-it/cli/azure/ad/sp?view=azure-cli-latest#az_ad_sp_create_for_rbac
  provisioner "local-exec" {
    command = <<EOT
      CREDENTIAL_VALUE=$(az ad sp create-for-rbac \
        --name "azdo-sp-acme-challenge-${local.secret_name}" \
        --role "DNS Zone Contributor" \
        --scope "/subscriptions/${self.triggers.subscription_id}/resourceGroups/${self.triggers.dns_zone_resource_group}/providers/Microsoft.Network/dnszones/${self.triggers.dns_zone_name}/TXT/${trim("_acme-challenge.${self.triggers.dns_record_name}", ".")}" \
        -o json)

      az keyvault secret set \
        --subscription "${self.triggers.credential_subcription}" \
        --vault-name "${self.triggers.credential_key_vault_name}" \
        --name "azdo-sp-acme-challenge-${local.secret_name}" \
        --value "$CREDENTIAL_VALUE"
    EOT
  }
```

to 

````
resource "null_resource" "this" {
  # needs az cli > 2.0.81
  # see https://github.com/Azure/azure-cli/issues/12152

  triggers = {
    renew_token               = var.renew_token
    subscription_id           = var.subscription_id
    subscription_name         = var.subscription_name
    credential_subcription    = var.credential_subcription
    credential_key_vault_name = var.credential_key_vault_name
    dns_record_name           = var.dns_record_name
    dns_zone_name             = var.dns_zone_name
    name                      = local.secret_name
    dns_zone_resource_group   = var.dns_zone_resource_group
  }

  # https://docs.microsoft.com/it-it/cli/azure/ad/sp?view=azure-cli-latest#az_ad_sp_create_for_rbac
  provisioner "local-exec" {
    command = <<EOT
      CREDENTIAL_VALUE=$(az ad sp create-for-rbac \
        --name "azdo-sp-acme-challenge-${local.secret_name}" \
        --role "DNS Zone Contributor" \
        --scope "/subscriptions/${self.triggers.subscription_id}/resourceGroups/${self.triggers.dns_zone_resource_group}/providers/Microsoft.Network/dnszones/${self.triggers.dns_zone_name}/TXT/${trim("_acme-challenge.${self.triggers.dns_record_name}", ".")}" \
        -o json)

      az keyvault secret set \
        --subscription "${self.triggers.credential_subcription}" \
        --vault-name "${self.triggers.credential_key_vault_name}" \
        --name "azdo-sp-acme-challenge-${local.secret_name}" \
        --value "$CREDENTIAL_VALUE"
    EOT
  }
```

changed self.triggers.name to local.secret_name because during the destroy lifecycle the trigger.name is not fired so the element into the map is not valorized and we cannot use it, and the module go in error

### Motivation and context

Errors during destroy phase

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
