### PR TITLE
fix: Use different pipeline for federated identity

### DIFF
--- a/azuredevops_build_definition_tls_cert_federated/main.tf
+++ b/azuredevops_build_definition_tls_cert_federated/main.tf
@@ -15,7 +15,7 @@ resource "azuredevops_build_definition" "pipeline" {
     repo_type             = "GitHub"
     repo_id               = "${var.repository.organization}/${var.repository.name}"
     branch_name           = var.repository.branch_name
-    yml_path              = "azure-pipelines.yaml"
+    yml_path              = "azure-pipelines-federated.yaml"
     service_connection_id = var.github_service_connection_id
   }
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Use different Azure DevOps pipeline for federated identity, named `azure-pipelines-federated.yaml`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This ensures better backward compatibility with legacy pipelines using service principals with secrets.

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module
- [ ] Other

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
