### PR TITLE
fix: Replace deprecated resource authorization

### DIFF
--- a/azuredevops_build_definition_certaz/README.md
+++ b/azuredevops_build_definition_certaz/README.md
@@ -30,8 +30,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [azuredevops_build_definition.pipeline](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/build_definition) | resource |
-| [azuredevops_resource_authorization.github_service_connection_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
-| [azuredevops_resource_authorization.service_connection_ids_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
+| [azuredevops_pipeline_authorization.github_service_connection_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
+| [azuredevops_pipeline_authorization.service_connection_ids_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
 | [time_sleep.wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 
 ## Inputs

--- a/azuredevops_build_definition_certaz/main.tf
+++ b/azuredevops_build_definition_certaz/main.tf
@@ -45,24 +45,22 @@ resource "time_sleep" "wait" {
 }
 
 # github_service_connection_id serviceendpoint authorization
-resource "azuredevops_resource_authorization" "github_service_connection_authorization" {
+resource "azuredevops_pipeline_authorization" "github_service_connection_authorization" {
   depends_on = [azuredevops_build_definition.pipeline, time_sleep.wait]
 
-  project_id    = var.project_id
-  resource_id   = var.github_service_connection_id
-  definition_id = azuredevops_build_definition.pipeline.id
-  authorized    = true
-  type          = "endpoint"
+  project_id  = var.project_id
+  resource_id = var.github_service_connection_id
+  pipeline_id = azuredevops_build_definition.pipeline.id
+  type        = "endpoint"
 }
 
 # others service_connection_ids serviceendpoint authorization
-resource "azuredevops_resource_authorization" "service_connection_ids_authorization" {
+resource "azuredevops_pipeline_authorization" "service_connection_ids_authorization" {
   depends_on = [azuredevops_build_definition.pipeline, time_sleep.wait]
   count      = var.service_connection_ids_authorization == null ? 0 : length(var.service_connection_ids_authorization)
 
-  project_id    = var.project_id
-  resource_id   = var.service_connection_ids_authorization[count.index]
-  definition_id = azuredevops_build_definition.pipeline.id
-  authorized    = true
-  type          = "endpoint"
+  project_id  = var.project_id
+  resource_id = var.service_connection_ids_authorization[count.index]
+  pipeline_id = azuredevops_build_definition.pipeline.id
+  type        = "endpoint"
 }

--- a/azuredevops_build_definition_code_review/README.md
+++ b/azuredevops_build_definition_code_review/README.md
@@ -107,8 +107,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [azuredevops_build_definition.pipeline](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/build_definition) | resource |
-| [azuredevops_resource_authorization.github_service_connection_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
-| [azuredevops_resource_authorization.service_connection_ids_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
+| [azuredevops_pipeline_authorization.github_service_connection_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
+| [azuredevops_pipeline_authorization.service_connection_ids_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
 | [time_sleep.wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 
 ## Inputs

--- a/azuredevops_build_definition_code_review/main.tf
+++ b/azuredevops_build_definition_code_review/main.tf
@@ -87,24 +87,22 @@ resource "time_sleep" "wait" {
 }
 
 # github_service_connection_id serviceendpoint authorization
-resource "azuredevops_resource_authorization" "github_service_connection_authorization" {
+resource "azuredevops_pipeline_authorization" "github_service_connection_authorization" {
   depends_on = [azuredevops_build_definition.pipeline, time_sleep.wait]
 
-  project_id    = var.project_id
-  resource_id   = var.github_service_connection_id
-  definition_id = azuredevops_build_definition.pipeline.id
-  authorized    = true
-  type          = "endpoint"
+  project_id  = var.project_id
+  resource_id = var.github_service_connection_id
+  pipeline_id = azuredevops_build_definition.pipeline.id
+  type        = "endpoint"
 }
 
 # others service_connection_ids serviceendpoint authorization
-resource "azuredevops_resource_authorization" "service_connection_ids_authorization" {
+resource "azuredevops_pipeline_authorization" "service_connection_ids_authorization" {
   depends_on = [azuredevops_build_definition.pipeline, time_sleep.wait]
   count      = var.service_connection_ids_authorization == null ? 0 : length(var.service_connection_ids_authorization)
 
-  project_id    = var.project_id
-  resource_id   = var.service_connection_ids_authorization[count.index]
-  definition_id = azuredevops_build_definition.pipeline.id
-  authorized    = true
-  type          = "endpoint"
+  project_id  = var.project_id
+  resource_id = var.service_connection_ids_authorization[count.index]
+  pipeline_id = azuredevops_build_definition.pipeline.id
+  type        = "endpoint"
 }

--- a/azuredevops_build_definition_deploy/README.md
+++ b/azuredevops_build_definition_deploy/README.md
@@ -95,8 +95,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [azuredevops_build_definition.pipeline](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/build_definition) | resource |
-| [azuredevops_resource_authorization.github_service_connection_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
-| [azuredevops_resource_authorization.service_connection_ids_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
+| [azuredevops_pipeline_authorization.github_service_connection_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
+| [azuredevops_pipeline_authorization.service_connection_ids_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
 | [time_sleep.wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 
 ## Inputs

--- a/azuredevops_build_definition_deploy/main.tf
+++ b/azuredevops_build_definition_deploy/main.tf
@@ -124,24 +124,22 @@ resource "time_sleep" "wait" {
 }
 
 # github_service_connection_id serviceendpoint authorization
-resource "azuredevops_resource_authorization" "github_service_connection_authorization" {
+resource "azuredevops_pipeline_authorization" "github_service_connection_authorization" {
   depends_on = [azuredevops_build_definition.pipeline, time_sleep.wait]
 
-  project_id    = var.project_id
-  resource_id   = var.github_service_connection_id
-  definition_id = azuredevops_build_definition.pipeline.id
-  authorized    = true
-  type          = "endpoint"
+  project_id  = var.project_id
+  resource_id = var.github_service_connection_id
+  pipeline_id = azuredevops_build_definition.pipeline.id
+  type        = "endpoint"
 }
 
 # others service_connection_ids serviceendpoint authorization
-resource "azuredevops_resource_authorization" "service_connection_ids_authorization" {
+resource "azuredevops_pipeline_authorization" "service_connection_ids_authorization" {
   depends_on = [azuredevops_build_definition.pipeline, time_sleep.wait]
   count      = var.service_connection_ids_authorization == null ? 0 : length(var.service_connection_ids_authorization)
 
-  project_id    = var.project_id
-  resource_id   = var.service_connection_ids_authorization[count.index]
-  definition_id = azuredevops_build_definition.pipeline.id
-  authorized    = true
-  type          = "endpoint"
+  project_id  = var.project_id
+  resource_id = var.service_connection_ids_authorization[count.index]
+  pipeline_id = azuredevops_build_definition.pipeline.id
+  type        = "endpoint"
 }

--- a/azuredevops_build_definition_generic/README.md
+++ b/azuredevops_build_definition_generic/README.md
@@ -19,8 +19,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [azuredevops_build_definition.pipeline](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/build_definition) | resource |
-| [azuredevops_resource_authorization.github_service_connection_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
-| [azuredevops_resource_authorization.service_connection_ids_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
+| [azuredevops_pipeline_authorization.github_service_connection_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
+| [azuredevops_pipeline_authorization.service_connection_ids_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
 | [time_sleep.wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 
 ## Inputs

--- a/azuredevops_build_definition_generic/main.tf
+++ b/azuredevops_build_definition_generic/main.tf
@@ -108,24 +108,22 @@ resource "time_sleep" "wait" {
 }
 
 # github_service_connection_id serviceendpoint authorization
-resource "azuredevops_resource_authorization" "github_service_connection_authorization" {
+resource "azuredevops_pipeline_authorization" "github_service_connection_authorization" {
   depends_on = [azuredevops_build_definition.pipeline, time_sleep.wait]
 
-  project_id    = var.project_id
-  resource_id   = var.github_service_connection_id
-  definition_id = azuredevops_build_definition.pipeline.id
-  authorized    = true
-  type          = "endpoint"
+  project_id  = var.project_id
+  resource_id = var.github_service_connection_id
+  pipeline_id = azuredevops_build_definition.pipeline.id
+  type        = "endpoint"
 }
 
 # others service_connection_ids serviceendpoint authorization
-resource "azuredevops_resource_authorization" "service_connection_ids_authorization" {
+resource "azuredevops_pipeline_authorization" "service_connection_ids_authorization" {
   depends_on = [azuredevops_build_definition.pipeline, time_sleep.wait]
   count      = var.service_connection_ids_authorization == null ? 0 : length(var.service_connection_ids_authorization)
 
-  project_id    = var.project_id
-  resource_id   = var.service_connection_ids_authorization[count.index]
-  definition_id = azuredevops_build_definition.pipeline.id
-  authorized    = true
-  type          = "endpoint"
+  project_id  = var.project_id
+  resource_id = var.service_connection_ids_authorization[count.index]
+  pipeline_id = azuredevops_build_definition.pipeline.id
+  type        = "endpoint"
 }

--- a/azuredevops_build_definition_resource_switcher/README.md
+++ b/azuredevops_build_definition_resource_switcher/README.md
@@ -203,10 +203,10 @@ No modules.
 |------|------|
 | [azuredevops_build_definition.aks_pipeline](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/build_definition) | resource |
 | [azuredevops_build_definition.sa_pipeline](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/build_definition) | resource |
-| [azuredevops_resource_authorization.aks_github_service_connection_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
-| [azuredevops_resource_authorization.aks_service_connection_ids_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
-| [azuredevops_resource_authorization.sa_github_service_connection_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
-| [azuredevops_resource_authorization.sa_service_connection_ids_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
+| [azuredevops_pipeline_authorization.aks_github_service_connection_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
+| [azuredevops_pipeline_authorization.aks_service_connection_ids_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
+| [azuredevops_pipeline_authorization.sa_github_service_connection_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
+| [azuredevops_pipeline_authorization.sa_service_connection_ids_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
 | [time_sleep.aks_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.sa_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 

--- a/azuredevops_build_definition_resource_switcher/aks_pipeline.tf
+++ b/azuredevops_build_definition_resource_switcher/aks_pipeline.tf
@@ -180,16 +180,15 @@ resource "time_sleep" "aks_wait" {
 }
 
 # github_service_connection_id serviceendpoint authorization
-resource "azuredevops_resource_authorization" "aks_github_service_connection_authorization" {
+resource "azuredevops_pipeline_authorization" "aks_github_service_connection_authorization" {
   count      = length(local.aks_config)
   depends_on = [azuredevops_build_definition.aks_pipeline, time_sleep.aks_wait]
 
-  project_id    = var.project_id
-  resource_id   = var.github_service_connection_id
-  definition_id = azuredevops_build_definition.aks_pipeline[count.index].id
+  project_id  = var.project_id
+  resource_id = var.github_service_connection_id
+  pipeline_id = azuredevops_build_definition.aks_pipeline[count.index].id
 
-  authorized = true
-  type       = "endpoint"
+  type = "endpoint"
 }
 
 
@@ -217,15 +216,14 @@ resource "azuredevops_resource_authorization" "aks_github_service_connection_aut
 #                     count.index        floor(count.index/ number of service connection ids)         count.index % number of service connection ids
 ##############################################################################################################################
 # others service_connection_ids serviceendpoint authorization
-resource "azuredevops_resource_authorization" "aks_service_connection_ids_authorization" {
+resource "azuredevops_pipeline_authorization" "aks_service_connection_ids_authorization" {
   depends_on = [azuredevops_build_definition.aks_pipeline, time_sleep.aks_wait]
   count      = local.service_connection_ids_clusters_total_combinations_count
 
-  project_id    = var.project_id
-  resource_id   = var.service_connection_ids_authorization[count.index % length(var.service_connection_ids_authorization)]
-  definition_id = azuredevops_build_definition.aks_pipeline[floor(count.index / length(var.service_connection_ids_authorization))].id
+  project_id  = var.project_id
+  resource_id = var.service_connection_ids_authorization[count.index % length(var.service_connection_ids_authorization)]
+  pipeline_id = azuredevops_build_definition.aks_pipeline[floor(count.index / length(var.service_connection_ids_authorization))].id
 
-  authorized = true
-  type       = "endpoint"
+  type = "endpoint"
 }
 

--- a/azuredevops_build_definition_resource_switcher/storage_account_pipeline.tf
+++ b/azuredevops_build_definition_resource_switcher/storage_account_pipeline.tf
@@ -114,16 +114,15 @@ resource "time_sleep" "sa_wait" {
 }
 
 # github_service_connection_id serviceendpoint authorization
-resource "azuredevops_resource_authorization" "sa_github_service_connection_authorization" {
+resource "azuredevops_pipeline_authorization" "sa_github_service_connection_authorization" {
   count      = length(local.aks_config)
   depends_on = [azuredevops_build_definition.aks_pipeline, time_sleep.sa_wait]
 
-  project_id    = var.project_id
-  resource_id   = var.github_service_connection_id
-  definition_id = azuredevops_build_definition.aks_pipeline[count.index].id
+  project_id  = var.project_id
+  resource_id = var.github_service_connection_id
+  pipeline_id = azuredevops_build_definition.aks_pipeline[count.index].id
 
-  authorized = true
-  type       = "endpoint"
+  type = "endpoint"
 }
 
 
@@ -151,15 +150,14 @@ resource "azuredevops_resource_authorization" "sa_github_service_connection_auth
 #                     count.index        floor(count.index/ number of service connection ids)         count.index % number of service connection ids
 ##############################################################################################################################
 # others service_connection_ids serviceendpoint authorization
-resource "azuredevops_resource_authorization" "sa_service_connection_ids_authorization" {
+resource "azuredevops_pipeline_authorization" "sa_service_connection_ids_authorization" {
   depends_on = [azuredevops_build_definition.aks_pipeline, time_sleep.sa_wait]
   count      = local.service_connection_ids_sa_total_combinations_count
 
-  project_id    = var.project_id
-  resource_id   = var.service_connection_ids_authorization[count.index % length(var.service_connection_ids_authorization)]
-  definition_id = azuredevops_build_definition.aks_pipeline[floor(count.index / length(var.service_connection_ids_authorization))].id
+  project_id  = var.project_id
+  resource_id = var.service_connection_ids_authorization[count.index % length(var.service_connection_ids_authorization)]
+  pipeline_id = azuredevops_build_definition.aks_pipeline[floor(count.index / length(var.service_connection_ids_authorization))].id
 
-  authorized = true
-  type       = "endpoint"
+  type = "endpoint"
 }
 

--- a/azuredevops_build_definition_tls_cert/README.md
+++ b/azuredevops_build_definition_tls_cert/README.md
@@ -35,8 +35,8 @@ Module that allows:
 | Name | Type |
 |------|------|
 | [azuredevops_build_definition.pipeline](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/build_definition) | resource |
-| [azuredevops_resource_authorization.github_service_connection_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
-| [azuredevops_resource_authorization.service_connection_ids_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
+| [azuredevops_pipeline_authorization.github_service_connection_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
+| [azuredevops_pipeline_authorization.service_connection_ids_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
 | [null_resource.this](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [time_sleep.wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 

--- a/azuredevops_build_definition_tls_cert/main.tf
+++ b/azuredevops_build_definition_tls_cert/main.tf
@@ -135,28 +135,26 @@ resource "time_sleep" "wait" {
 }
 
 # github_service_connection_id serviceendpoint authorization
-resource "azuredevops_resource_authorization" "github_service_connection_authorization" {
+resource "azuredevops_pipeline_authorization" "github_service_connection_authorization" {
   depends_on = [azuredevops_build_definition.pipeline, time_sleep.wait]
 
-  project_id    = var.project_id
-  resource_id   = var.github_service_connection_id
-  definition_id = azuredevops_build_definition.pipeline.id
+  project_id  = var.project_id
+  resource_id = var.github_service_connection_id
+  pipeline_id = azuredevops_build_definition.pipeline.id
 
-  authorized = true
-  type       = "endpoint"
+  type = "endpoint"
 }
 
 # others service_connection_ids serviceendpoint authorization
-resource "azuredevops_resource_authorization" "service_connection_ids_authorization" {
+resource "azuredevops_pipeline_authorization" "service_connection_ids_authorization" {
   depends_on = [azuredevops_build_definition.pipeline, time_sleep.wait]
   count      = var.service_connection_ids_authorization == null ? 0 : length(var.service_connection_ids_authorization)
 
-  project_id    = var.project_id
-  resource_id   = var.service_connection_ids_authorization[count.index]
-  definition_id = azuredevops_build_definition.pipeline.id
+  project_id  = var.project_id
+  resource_id = var.service_connection_ids_authorization[count.index]
+  pipeline_id = azuredevops_build_definition.pipeline.id
 
-  authorized = true
-  type       = "endpoint"
+  type = "endpoint"
 }
 
 resource "null_resource" "this" {

--- a/azuredevops_build_definition_tls_cert_federated/README.md
+++ b/azuredevops_build_definition_tls_cert_federated/README.md
@@ -35,9 +35,9 @@ Module that allows:
 | Name | Type |
 |------|------|
 | [azuredevops_build_definition.pipeline](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/build_definition) | resource |
-| [azuredevops_resource_authorization.github_service_connection_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
-| [azuredevops_resource_authorization.service_connection_ids_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
-| [azuredevops_resource_authorization.service_connection_le_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/resource_authorization) | resource |
+| [azuredevops_pipeline_authorization.github_service_connection_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
+| [azuredevops_pipeline_authorization.service_connection_ids_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
+| [azuredevops_pipeline_authorization.service_connection_le_authorization](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) | resource |
 | [azurerm_role_assignment.managed_identity_default_role_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [time_sleep.wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 

--- a/azuredevops_build_definition_tls_cert_federated/README.md
+++ b/azuredevops_build_definition_tls_cert_federated/README.md
@@ -53,7 +53,6 @@ Module that allows:
 | <a name="input_dns_zone_resource_group"></a> [dns\_zone\_resource\_group](#input\_dns\_zone\_resource\_group) | (Required) Dns zone resource group name | `string` | n/a | yes |
 | <a name="input_github_service_connection_id"></a> [github\_service\_connection\_id](#input\_github\_service\_connection\_id) | (Required) GitHub service connection ID used to link Azure DevOps. | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | (Required) Pipeline name equals to domain name | `string` | n/a | yes |
 | <a name="input_path"></a> [path](#input\_path) | (Required) Pipeline path on Azure DevOps | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | (Required) Azure DevOps project ID | `string` | n/a | yes |
 | <a name="input_repository"></a> [repository](#input\_repository) | (Required) GitHub repository attributes | <pre>object({<br>    organization   = string<br>    name           = string<br>    branch_name    = string<br>    pipelines_path = string<br>  })</pre> | n/a | yes |

--- a/azuredevops_build_definition_tls_cert_federated/main.tf
+++ b/azuredevops_build_definition_tls_cert_federated/main.tf
@@ -7,7 +7,7 @@ resource "azuredevops_build_definition" "pipeline" {
   depends_on = [module.secrets]
 
   project_id      = var.project_id
-  name            = trim(var.name, ".")
+  name            = trimprefix("${var.dns_record_name}.${var.dns_zone_name}", ".")
   path            = "\\${var.path}"
   agent_pool_name = var.agent_pool_name
 

--- a/azuredevops_build_definition_tls_cert_federated/main.tf
+++ b/azuredevops_build_definition_tls_cert_federated/main.tf
@@ -133,39 +133,33 @@ resource "time_sleep" "wait" {
 }
 
 # github_service_connection_id serviceendpoint authorization
-resource "azuredevops_resource_authorization" "github_service_connection_authorization" {
+resource "azuredevops_pipeline_authorization" "github_service_connection_authorization" {
   depends_on = [azuredevops_build_definition.pipeline, time_sleep.wait]
 
-  project_id    = var.project_id
-  resource_id   = var.github_service_connection_id
-  definition_id = azuredevops_build_definition.pipeline.id
-
-  authorized = true
-  type       = "endpoint"
+  project_id  = var.project_id
+  resource_id = var.github_service_connection_id
+  pipeline_id = azuredevops_build_definition.pipeline.id
+  type        = "endpoint"
 }
 
 # others service_connection_ids serviceendpoint authorization
-resource "azuredevops_resource_authorization" "service_connection_ids_authorization" {
+resource "azuredevops_pipeline_authorization" "service_connection_ids_authorization" {
   depends_on = [azuredevops_build_definition.pipeline, time_sleep.wait]
   count      = var.service_connection_ids_authorization == null ? 0 : length(var.service_connection_ids_authorization)
 
-  project_id    = var.project_id
-  resource_id   = var.service_connection_ids_authorization[count.index]
-  definition_id = azuredevops_build_definition.pipeline.id
-
-  authorized = true
-  type       = "endpoint"
+  project_id  = var.project_id
+  resource_id = var.service_connection_ids_authorization[count.index]
+  pipeline_id = azuredevops_build_definition.pipeline.id
+  type        = "endpoint"
 }
 
-resource "azuredevops_resource_authorization" "service_connection_le_authorization" {
-  depends_on = [azuredevops_build_definition.pipeline, time_sleep.wait]
+resource "azuredevops_pipeline_authorization" "service_connection_le_authorization" {
+  depends_on = [time_sleep.wait]
 
-  project_id    = var.project_id
-  resource_id   = module.azuredevops_serviceendpoint_federated.service_endpoint_id
-  definition_id = azuredevops_build_definition.pipeline.id
-
-  authorized = true
-  type       = "endpoint"
+  project_id  = var.project_id
+  resource_id = module.azuredevops_serviceendpoint_federated.service_endpoint_id
+  pipeline_id = azuredevops_build_definition.pipeline.id
+  type        = "endpoint"
 }
 
 # service endpoint for federated authorizion, used for accessing dns txt record of acme challenge

--- a/azuredevops_build_definition_tls_cert_federated/variables.tf
+++ b/azuredevops_build_definition_tls_cert_federated/variables.tf
@@ -17,11 +17,6 @@ variable "repository" {
   description = "(Required) GitHub repository attributes"
 }
 
-variable "name" {
-  type        = string
-  description = "(Required) Pipeline name equals to domain name"
-}
-
 variable "agent_pool_name" {
   type        = string
   default     = "Azure Pipelines"


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Replace deprecated resource `azuredevops_resource_authorization` with `azuredevops_pipeline_authorization`.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
According to [provider documentation](https://registry.terraform.io/providers/microsoft/azuredevops/0.10.0/docs/resources/pipeline_authorization), the latter is a replacement of the former, now deprecated.

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module
- [ ] Other

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

It does cause deletion and creation of authorization resources, but should not cause any modifications in usage.

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
