### PR TITLE
fix: Force azuredevops provider to be 0.10.x

### DIFF
--- a/azuredevops_build_definition_certaz/README.md
+++ b/azuredevops_build_definition_certaz/README.md
@@ -17,7 +17,7 @@ Module that allows the creation of a pipeline dedicated to code review of terraf
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | <= 0.10.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 0.10.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.71.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7.0 |
 

--- a/azuredevops_build_definition_certaz/versions.tf
+++ b/azuredevops_build_definition_certaz/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "<= 0.10.0"
+      version = "~> 0.10.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/azuredevops_build_definition_code_review/README.md
+++ b/azuredevops_build_definition_code_review/README.md
@@ -94,7 +94,7 @@ module "io-pn-mock_code_review" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | <= 0.10.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 0.10.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.71.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7.0 |
 

--- a/azuredevops_build_definition_code_review/versions.tf
+++ b/azuredevops_build_definition_code_review/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "<= 0.10.0"
+      version = "~> 0.10.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/azuredevops_build_definition_deploy/README.md
+++ b/azuredevops_build_definition_deploy/README.md
@@ -82,7 +82,7 @@ module "io-pn-mock-variables_deploy" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | <= 0.10.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 0.10.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.71.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7.0 |
 

--- a/azuredevops_build_definition_deploy/versions.tf
+++ b/azuredevops_build_definition_deploy/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "<= 0.10.0"
+      version = "~> 0.10.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/azuredevops_build_definition_generic/README.md
+++ b/azuredevops_build_definition_generic/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | <= 0.10.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 0.10.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.71.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7.0 |
 

--- a/azuredevops_build_definition_generic/versions.tf
+++ b/azuredevops_build_definition_generic/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "<= 0.10.0"
+      version = "~> 0.10.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/azuredevops_build_definition_resource_switcher/README.md
+++ b/azuredevops_build_definition_resource_switcher/README.md
@@ -188,7 +188,7 @@ You'll have to create your own, customizing the parameters reading section, and 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | <= 0.10.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 0.10.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.71.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 1.3.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7.0 |

--- a/azuredevops_build_definition_resource_switcher/versions.tf
+++ b/azuredevops_build_definition_resource_switcher/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "<= 0.10.0"
+      version = "~> 0.10.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/azuredevops_build_definition_tls_cert/README.md
+++ b/azuredevops_build_definition_tls_cert/README.md
@@ -19,7 +19,7 @@ Module that allows:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | <= 0.10.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 0.10.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.71.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 1.3.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7.0 |

--- a/azuredevops_build_definition_tls_cert/versions.tf
+++ b/azuredevops_build_definition_tls_cert/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "<= 0.10.0"
+      version = "~> 0.10.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/azuredevops_build_definition_tls_cert_federated/README.md
+++ b/azuredevops_build_definition_tls_cert_federated/README.md
@@ -19,7 +19,7 @@ Module that allows:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | <= 0.10.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 0.10.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.71.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7.0 |
 

--- a/azuredevops_build_definition_tls_cert_federated/versions.tf
+++ b/azuredevops_build_definition_tls_cert_federated/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "<= 0.10.0"
+      version = "~> 0.10.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/azuredevops_serviceendpoint_azurerm_limited/README.md
+++ b/azuredevops_serviceendpoint_azurerm_limited/README.md
@@ -46,7 +46,7 @@ locals {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 2.10.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | <= 0.10.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 0.10.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.71.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 1.3.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7.0 |

--- a/azuredevops_serviceendpoint_azurerm_limited/versions.tf
+++ b/azuredevops_serviceendpoint_azurerm_limited/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "<= 0.10.0"
+      version = "~> 0.10.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/azuredevops_serviceendpoint_azurerm_plan/README.md
+++ b/azuredevops_serviceendpoint_azurerm_plan/README.md
@@ -50,7 +50,7 @@ module "DEV-CSTAR-PLAN-SERVICE-CONN" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 2.10.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | <= 0.10.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 0.10.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.71.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 1.3.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7.0 |

--- a/azuredevops_serviceendpoint_azurerm_plan/versions.tf
+++ b/azuredevops_serviceendpoint_azurerm_plan/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "<= 0.10.0"
+      version = "~> 0.10.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/azuredevops_serviceendpoint_federated/README.md
+++ b/azuredevops_serviceendpoint_federated/README.md
@@ -45,7 +45,7 @@ locals {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | <= 0.10.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 0.10.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.71.0 |
 
 ## Modules

--- a/azuredevops_serviceendpoint_federated/versions.tf
+++ b/azuredevops_serviceendpoint_federated/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "<= 0.10.0"
+      version = "~> 0.10.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Updates `versions.tf` files to force `"~> 0.10.0"` version for `"microsoft/azuredevops"`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Modules don't work with older versions

### Type of changes

- [ ] Add new module
- [X] Update existing module
- [ ] Remove existing module
- [ ] Other

### Does this introduce a breaking change?

- [X] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
