### PR TITLE
fix: Bump version of azuredevops_serviceendpoint_federated dep

### DIFF
--- a/azuredevops_build_definition_tls_cert_federated/README.md
+++ b/azuredevops_build_definition_tls_cert_federated/README.md
@@ -27,7 +27,7 @@ Module that allows:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_azuredevops_serviceendpoint_federated"></a> [azuredevops\_serviceendpoint\_federated](#module\_azuredevops\_serviceendpoint\_federated) | git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated | v4.0.0 |
+| <a name="module_azuredevops_serviceendpoint_federated"></a> [azuredevops\_serviceendpoint\_federated](#module\_azuredevops\_serviceendpoint\_federated) | git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated | v4.1.3 |
 | <a name="module_secrets"></a> [secrets](#module\_secrets) | git::https://github.com/pagopa/terraform-azurerm-v3.git//key_vault_secrets_query | v6.15.2 |
 
 ## Resources

--- a/azuredevops_build_definition_tls_cert_federated/main.tf
+++ b/azuredevops_build_definition_tls_cert_federated/main.tf
@@ -164,7 +164,7 @@ resource "azuredevops_pipeline_authorization" "service_connection_le_authorizati
 
 # service endpoint for federated authorizion, used for accessing dns txt record of acme challenge
 module "azuredevops_serviceendpoint_federated" {
-  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated?ref=v4.0.0"
+  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated?ref=v4.1.3"
 
   project_id          = var.project_id
   name                = "azdo-acme-challenge-${local.secret_name}"


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

Bump version of a module dependency.

### List of changes

<!--- Describe your changes in detail -->
Bump version of module `azuredevops_serviceendpoint_federated` used in module `azuredevops_build_definition_tls_cert_federated` to version v4.1.3.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The deprecated resource `azuredevops_resource_authorization` is still used in the module in the old version.

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module
- [ ] Other

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
