### PR TITLE
feat: Serviceendpoint_azurerm_plan -> removed data for group_directory_reader_permissions

### DIFF
--- a/azuredevops_serviceendpoint_azurerm_plan/README.md
+++ b/azuredevops_serviceendpoint_azurerm_plan/README.md
@@ -67,14 +67,12 @@ module "DEV-CSTAR-PLAN-SERVICE-CONN" {
 |------|------|
 | [azuread_application.plan_app](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
 | [azuread_application_password.plan_app](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_password) | resource |
-| [azuread_group_member.add_plan_app_to_directory_readers_group](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/group_member) | resource |
 | [azuread_service_principal.sp_plan](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
 | [azuredevops_serviceendpoint_azurerm.this](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/serviceendpoint_azurerm) | resource |
 | [azurerm_key_vault_secret.credentials_password_value](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_role_assignment.default_resource_group_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.plan_app_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [time_rotating.credential_password_days](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/rotating) | resource |
-| [azuread_group.group_directory_reader_permissions](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azurerm_key_vault.kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_subscription.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
@@ -87,7 +85,6 @@ module "DEV-CSTAR-PLAN-SERVICE-CONN" {
 | <a name="input_credential_key_vault_resource_group"></a> [credential\_key\_vault\_resource\_group](#input\_credential\_key\_vault\_resource\_group) | (Required) Key vault resource group where store service principal credentials | `string` | n/a | yes |
 | <a name="input_default_resource_group_name"></a> [default\_resource\_group\_name](#input\_default\_resource\_group\_name) | The name of the default resource group to link with the new app to allow the connection | `string` | `"default-roleassignment-rg"` | no |
 | <a name="input_default_roleassignment_rg_prefix"></a> [default\_roleassignment\_rg\_prefix](#input\_default\_roleassignment\_rg\_prefix) | (Optional) Add a prefix to default\_roleassignment\_rg | `string` | `""` | no |
-| <a name="input_iac_aad_group_name"></a> [iac\_aad\_group\_name](#input\_iac\_aad\_group\_name) | Azure AD group name for iac sp apps (with Directory Reader permissions at leats) | `string` | n/a | yes |
 | <a name="input_name_suffix"></a> [name\_suffix](#input\_name\_suffix) | (Required) Service principal name suffix | `string` | n/a | yes |
 | <a name="input_password_time_rotation_days"></a> [password\_time\_rotation\_days](#input\_password\_time\_rotation\_days) | How many days before the password(credentials) is rotated | `number` | `365` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | (Required) Azure DevOps project ID | `string` | n/a | yes |
@@ -99,7 +96,7 @@ module "DEV-CSTAR-PLAN-SERVICE-CONN" {
 
 | Name | Description |
 |------|-------------|
-| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | App name |
+| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | Azure app name |
 | <a name="output_application_id"></a> [application\_id](#output\_application\_id) | Service principal application id |
 | <a name="output_service_endpoint_id"></a> [service\_endpoint\_id](#output\_service\_endpoint\_id) | Service endpoint id |
 | <a name="output_service_endpoint_name"></a> [service\_endpoint\_name](#output\_service\_endpoint\_name) | Service endpoint name |

--- a/azuredevops_serviceendpoint_azurerm_plan/main.tf
+++ b/azuredevops_serviceendpoint_azurerm_plan/main.tf
@@ -1,7 +1,3 @@
-data "azuread_group" "group_directory_reader_permissions" {
-  display_name = var.iac_aad_group_name
-}
-
 data "azurerm_key_vault" "kv" {
   name                = var.credential_key_vault_name
   resource_group_name = var.credential_key_vault_resource_group
@@ -50,12 +46,6 @@ resource "azurerm_key_vault_secret" "credentials_password_value" {
 #
 # Roles
 #
-
-# assign SP to group with Directory Reader
-resource "azuread_group_member" "add_plan_app_to_directory_readers_group" {
-  group_object_id  = data.azuread_group.group_directory_reader_permissions.id
-  member_object_id = azuread_service_principal.sp_plan.object_id
-}
 
 # assign SP to default resource group to allow to be linked to subscription
 resource "azurerm_role_assignment" "default_resource_group_reader" {

--- a/azuredevops_serviceendpoint_azurerm_plan/output.tf
+++ b/azuredevops_serviceendpoint_azurerm_plan/output.tf
@@ -6,7 +6,7 @@ output "application_id" {
 
 output "app_name" {
   value       = local.app_name
-  description = "App name"
+  description = "Azure app name"
 }
 
 output "service_principal_object_id" {

--- a/azuredevops_serviceendpoint_azurerm_plan/variables.tf
+++ b/azuredevops_serviceendpoint_azurerm_plan/variables.tf
@@ -28,16 +28,6 @@ variable "project_id" {
   description = "(Required) Azure DevOps project ID"
 }
 
-# variable "renew_token" {
-#   type        = string
-#   description = "(Required) Renew token to recreate service principal. Change it to renew service principal credentials"
-# }
-
-# variable "subscription_name" {
-#   type        = string
-#   description = "(Required) Azure Subscription name related to tenant where create service principal"
-# }
-
 variable "subscription_id" {
   type        = string
   description = "(Required) Azure Subscription ID related to tenant where create service principal"
@@ -47,11 +37,6 @@ variable "tenant_id" {
   type        = string
   description = "(Required) Azure Tenant ID related to tenant where create service principal"
 }
-
-# variable "credential_subcription" {
-#   type        = string
-#   description = "(Required) Azure Subscription where store service principal credentials"
-# }
 
 variable "credential_key_vault_name" {
   type        = string
@@ -73,11 +58,6 @@ variable "password_time_rotation_days" {
   type        = number
   description = "How many days before the password(credentials) is rotated"
   default     = 365
-}
-
-variable "iac_aad_group_name" {
-  type        = string
-  description = "Azure AD group name for iac sp apps (with Directory Reader permissions at leats)"
 }
 
 variable "default_resource_group_name" {


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

The group iac readers doesn't exists anymore, so we need to remove the data and use eng azure auth to link the new app to the new group


### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module
- [ ] Other

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
