### PR TITLE
breaking: cert-pipeline-definition force variable definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v8.x
+
+### azuredevops_build_definition_tls_cert_federated
+
+Don't use external variables:
+
+* `KEY_VAULT_NAME`
+* `CERT_NAME_EXPIRE_SECONDS`
+
+this variables are included into the module it self
+
 ## v3.0.0
 
 Upgrated azurerm version to v3

--- a/azuredevops_build_definition_tls_cert_federated/README.md
+++ b/azuredevops_build_definition_tls_cert_federated/README.md
@@ -22,134 +22,109 @@ This module manages the following resources:
 
 ![architecture](./docs/module-arch.drawio.png)
 
+## Migration
+
+### v8.x
+
+Don't use external variables:
+
+* `KEY_VAULT_NAME`
+* `CERT_NAME_EXPIRE_SECONDS`
+
+this variables are included into the module it self
+
 ## Usage
 
-Reference Azure DevOps project:
 ```hcl
-data "azuredevops_project" "project" {
-  name = "my-projects"
+variable "tlscert-testit-itn-internal-devopslab-pagopa-it" {
+  default = {
+    repository = {
+      organization   = "pagopa"
+      name           = "le-azure-acme-tiny"
+      branch_name    = "refs/heads/master"
+      pipelines_path = "."
+    }
+    pipeline = {
+      enable_tls_cert = true
+      path            = "TLS-Certificates\\DEV"
+      dns_record_name = "testit.itn.internal"
+      dns_zone_name   = "devopslab.pagopa.it"
+      # common variables to all pipelines
+      variables = {
+      }
+      # common secret variables to all pipelines
+      variables_secret = {
+      }
+    }
+  }
 }
-```
 
-Get the GitHub token from KV:
-```hcl
-module "secret_core" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3//key_vault_secrets_query?ref=v7.20.0"
-  resource_group = "my-kv-rg"
-  key_vault_name = "my-kv"
+locals {
+  tlscert-testit-itn-internal-devopslab-pagopa-it = {
+    tenant_id         = data.azurerm_client_config.current.tenant_id
+    subscription_name = data.azurerm_subscriptions.dev.subscriptions[0].display_name
+    subscription_id   = data.azurerm_subscriptions.dev.subscriptions[0].subscription_id
+  }
+  tlscert-testit-itn-internal-devopslab-pagopa-it-variables = {
+    KEY_VAULT_SERVICE_CONNECTION = module.DEV-PRINTIT-TLS-CERT-SERVICE-CONN.service_endpoint_name,
+  }
+  tlscert-testit-itn-internal-devopslab-pagopa-it-variables_secret = {
+  }
+}
 
-  secrets = [
-    "azure-devops-github-ro-TOKEN",
+module "tlscert-testit-itn-internal-devopslab-pagopa-it-cert_az" {
+
+  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert_federated?ref=fix-cert-pipeline-definition"
+  count  = var.tlscert-testit-itn-internal-devopslab-pagopa-it.pipeline.enable_tls_cert == true ? 1 : 0
+  providers = {
+    azurerm = azurerm.dev
+  }
+
+  project_id                   = data.azuredevops_project.project.id
+  repository                   = var.tlscert-testit-itn-internal-devopslab-pagopa-it.repository
+  path                         = var.tlscert-testit-itn-internal-devopslab-pagopa-it.pipeline.path
+  github_service_connection_id = data.azuredevops_serviceendpoint_github.github_rw.id
+
+  dns_record_name         = var.tlscert-testit-itn-internal-devopslab-pagopa-it.pipeline.dns_record_name
+  dns_zone_name           = var.tlscert-testit-itn-internal-devopslab-pagopa-it.pipeline.dns_zone_name
+  dns_zone_resource_group = var.internal_devopslab_dns_private_rg_name
+  tenant_id               = local.tlscert-testit-itn-internal-devopslab-pagopa-it.tenant_id
+  subscription_name       = local.tlscert-testit-itn-internal-devopslab-pagopa-it.subscription_name
+  subscription_id         = local.tlscert-testit-itn-internal-devopslab-pagopa-it.subscription_id
+  managed_identity_resource_group_name = var.identity_rg_name
+
+  credential_key_vault_name            = "${local.dev_domain_key_vault_name}"
+  credential_key_vault_resource_group  = local.dev_domain_key_vault_resource_group
+  location                = var.location
+
+  variables = merge(
+    var.tlscert-testit-itn-internal-devopslab-pagopa-it.pipeline.variables,
+    local.tlscert-testit-itn-internal-devopslab-pagopa-it-variables,
+  )
+
+  variables_secret = merge(
+    var.tlscert-testit-itn-internal-devopslab-pagopa-it.pipeline.variables_secret,
+    local.tlscert-testit-itn-internal-devopslab-pagopa-it-variables_secret,
+  )
+
+  service_connection_ids_authorization = [
+    module.DEV-PRINTIT-TLS-CERT-SERVICE-CONN.service_endpoint_id,
   ]
-}
-```
-
-Create a AZDO service connection for cloning pipeline repo (i.e., `le-azure-acme-tiny`)
-from GitHub with previously retrieved token:
-```hcl
-resource "azuredevops_serviceendpoint_github" "azure_devops_github_ro" {
-  project_id            = data.azuredevops_project.project.id
-  service_endpoint_name = "azure-devops-github-ro"
-  auth_personal {
-    personal_access_token = module.secret_core.values["azure-devops-github-ro-TOKEN"].value
-  }
-  lifecycle {
-    ignore_changes = [description, authorization]
-  }
-}
-```
-
-Get Let's Encrypt credentials and store them into KV (requires Docker, it runs a local provisioner):
-```hcl
-module "letsencrypt" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3//letsencrypt_credential?ref=v7.20.0"
-
-  prefix            = "my"
-  env               = "p"
-  key_vault_name    = "my-kv"
-  subscription_name = "my-sub"
-}
-```
-
-Create service connection and related managed identity for editing the certificate on KV:
-```hcl
-module "tls_cert_service_conn" {
-  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated?ref=v4.0.0"
-
-  project_id          = data.azuredevops_project.project.id
-  name                = "my-p-tls-cert"
-  tenant_id           = "my-tenant-id"
-  subscription_name   = "my-sub-name"
-  subscription_id     = "my-sub-id"
-  location            = "westeurope"
-  resource_group_name = "default-roleassignment-rg"
-}
-
-data "azurerm_key_vault" "kv" {
-  resource_group_name = "my-kv-rg"
-  name                = "my-kv"
-}
-
-resource "azurerm_key_vault_access_policy" "tls_cert_service_conn_kv_access_policy" {
-  key_vault_id = data.azurerm_key_vault.kv.id
-  tenant_id    = "my-tenant-id"
-  object_id    = module.tls_cert_service_conn.identity_principal_id
-  certificate_permissions = ["Get", "Import"]
-}
-```
-
-Finally, use this module for creating pipeline:
-```hcl
-module "tlscert-portalefatturazione-pagopa-it-cert_az" {
-  depends_on = [module.letsencrypt]
-
-  source = "git::<https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert_federated?ref=v4.1.5>"
-
-  project_id = data.azuredevops_project.project.id
-  location   = "westeurope"
-  repository = {
-    organization   = "pagopa"
-    name           = "le-azure-acme-tiny"
-    branch_name    = "refs/heads/master"
-    pipelines_path = "."
-  }
-  name                         = "my.pagopa.it"
-  path                         = "my\\TLS-Certificates"
-  github_service_connection_id = azuredevops_serviceendpoint_github.azure_devops_github_ro.id
-
-  dns_record_name         = ""
-  dns_zone_name           = "my.pagopa.it"
-  dns_zone_resource_group = "my-dns-rg"
-  tenant_id               = "my-tenant-id"
-  subscription_name       = "my-sub"
-  subscription_id         = "my-sub-id"
-
-  credential_key_vault_name           = "my-kv"
-  credential_key_vault_resource_group = "my-kv-rg"
-
-  variables = {
-    CERT_NAME_EXPIRE_SECONDS     = "2592000" #30 days
-    KEY_VAULT_SERVICE_CONNECTION = module.tls_cert_service_conn.service_endpoint_name,
-    KEY_VAULT_NAME               = "my-kv"
-  }
-  variables_secret = {}
-
-  service_connection_ids_authorization = [ module.tls_cert_service_conn.service_endpoint_id ]
 
   schedules = {
-    days_to_build              = ["Thu"]
+    days_to_build              = ["Fri"]
     schedule_only_with_changes = false
     start_hours                = 3
     start_minutes              = 0
     time_zone                  = "(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna"
     branch_filter = {
-      include = ["refs/heads/master"]
+      include = ["master"]
       exclude = []
     }
   }
 }
-```
 
+```
 
 <!-- markdownlint-disable -->
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/azuredevops_build_definition_tls_cert_federated/README.md
+++ b/azuredevops_build_definition_tls_cert_federated/README.md
@@ -160,6 +160,7 @@ module "tlscert-testit-itn-internal-devopslab-pagopa-it-cert_az" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_agent_pool_name"></a> [agent\_pool\_name](#input\_agent\_pool\_name) | The agent pool that should execute the build | `string` | `"Azure Pipelines"` | no |
+| <a name="input_cert_name_expire_seconds"></a> [cert\_name\_expire\_seconds](#input\_cert\_name\_expire\_seconds) | (Optional) Certficate expire in seconds. Default is '2592000' #30 days | `number` | `2592000` | no |
 | <a name="input_credential_key_vault_name"></a> [credential\_key\_vault\_name](#input\_credential\_key\_vault\_name) | (Required) key vault where store service principal credentials | `string` | n/a | yes |
 | <a name="input_credential_key_vault_resource_group"></a> [credential\_key\_vault\_resource\_group](#input\_credential\_key\_vault\_resource\_group) | (Required) key vault resource group where store service principal credentials | `string` | n/a | yes |
 | <a name="input_dns_record_name"></a> [dns\_record\_name](#input\_dns\_record\_name) | (Required) Dns record name | `string` | n/a | yes |

--- a/azuredevops_build_definition_tls_cert_federated/main.tf
+++ b/azuredevops_build_definition_tls_cert_federated/main.tf
@@ -101,6 +101,20 @@ resource "azuredevops_build_definition" "pipeline" {
   }
 
   variable {
+    name           = "LE_PRIVATE_KEY_JSON"
+    secret_value   = module.secrets.values["le-private-key-json"].value
+    is_secret      = true
+    allow_override = false
+  }
+
+  variable {
+    name           = "LE_REGR_JSON"
+    secret_value   = module.secrets.values["le-regr-json"].value
+    is_secret      = true
+    allow_override = false
+  }
+
+  variable {
     name           = "KEY_VAULT_CERT_NAME"
     value          = local.secret_name
     allow_override = false
@@ -113,16 +127,8 @@ resource "azuredevops_build_definition" "pipeline" {
   }
 
   variable {
-    name           = "LE_PRIVATE_KEY_JSON"
-    secret_value   = module.secrets.values["le-private-key-json"].value
-    is_secret      = true
-    allow_override = false
-  }
-
-  variable {
-    name           = "LE_REGR_JSON"
-    secret_value   = module.secrets.values["le-regr-json"].value
-    is_secret      = true
+    name           = "CERT_NAME_EXPIRE_SECONDS"
+    value          = var.cert_name_expire_seconds
     allow_override = false
   }
 

--- a/azuredevops_build_definition_tls_cert_federated/main.tf
+++ b/azuredevops_build_definition_tls_cert_federated/main.tf
@@ -107,6 +107,12 @@ resource "azuredevops_build_definition" "pipeline" {
   }
 
   variable {
+    name           = "KEY_VAULT_NAME"
+    value          = var.credential_key_vault_name
+    allow_override = false
+  }
+
+  variable {
     name           = "LE_PRIVATE_KEY_JSON"
     secret_value   = module.secrets.values["le-private-key-json"].value
     is_secret      = true

--- a/azuredevops_build_definition_tls_cert_federated/variables.tf
+++ b/azuredevops_build_definition_tls_cert_federated/variables.tf
@@ -72,6 +72,9 @@ variable "tenant_id" {
   description = "(Required) Azure Tenant ID related to tenant where create service principal"
 }
 
+#
+# 🔒 KV
+#
 variable "credential_key_vault_name" {
   type        = string
   description = "(Required) key vault where store service principal credentials"
@@ -82,6 +85,9 @@ variable "credential_key_vault_resource_group" {
   description = "(Required) key vault resource group where store service principal credentials"
 }
 
+#
+# DNS
+#
 variable "dns_record_name" {
   type        = string
   description = "(Required) Dns record name"
@@ -100,6 +106,12 @@ variable "dns_zone_resource_group" {
 variable "managed_identity_resource_group_name" {
   type        = string
   description = "(Required) Managed identity resource group, where will be created"
+}
+
+variable "cert_name_expire_seconds" {
+  type = number
+  description = "(Optional) Certficate expire in seconds. Default is '2592000' #30 days"
+  default = 2592000
 }
 
 variable "schedules" {

--- a/azuredevops_build_definition_tls_cert_federated/variables.tf
+++ b/azuredevops_build_definition_tls_cert_federated/variables.tf
@@ -109,9 +109,9 @@ variable "managed_identity_resource_group_name" {
 }
 
 variable "cert_name_expire_seconds" {
-  type = number
+  type        = number
   description = "(Optional) Certficate expire in seconds. Default is '2592000' #30 days"
-  default = 2592000
+  default     = 2592000
 }
 
 variable "schedules" {


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

azuredevops_build_definition_tls_cert_federated:

- force KEY_VAULT_NAME & CERT_NAME_EXPIRATION to avoid problem


### Motivation and context

This two variables may be forgotten and make a lot of problems

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module
- [ ] Other

### Does this introduce a breaking change?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
